### PR TITLE
Use /flynn/busybox image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM flynn/busybox
 MAINTAINER Jeff Lindsay <progrium@gmail.com>
 
 ADD ./build/shelf /bin/shelf


### PR DESCRIPTION
With stackbrew/busybox I first ran into the DNS bug (https://github.com/dotcloud/docker/issues/2468), and the image from 2013-02-04 cannot execute the go binaries for some reason (Not found).

Might as well go with a trusted base image.

Signed-off-by: Michael Elsdörfer michael@elsdoerfer.com
